### PR TITLE
Permitindo envio do campo ID para criação de NFSE

### DIFF
--- a/src/Api/Operations/Issue.php
+++ b/src/Api/Operations/Issue.php
@@ -76,6 +76,9 @@ class Issue implements APIOperation
         if (!is_null($this->ForIssuance->getUrlNotificacao())) {
             $this->toSend->url_notificacao = $this->ForIssuance->getUrlNotificacao();
         }
+        if (!is_null($this->ForIssuance->getID())) {
+            $this->toSend->ID = $this->ForIssuance->getID();
+        }
         if (!is_null($this->ForIssuance->getAgendamento())) {
             $this->toSend->agendar = $this->ForIssuance->getAgendamento()->format('Y-m-d H:m:s');
         }

--- a/src/Interfaces/DocumentForIssuance.php
+++ b/src/Interfaces/DocumentForIssuance.php
@@ -14,6 +14,12 @@ interface DocumentForIssuance
     public function getUrlNotificacao();
 
     /**
+     * Retorna o ID único para criação da NFSe
+     * @return string|null
+     */
+    public function getID();
+
+    /**
      * Retorna a data/hora para agendamento de emissão.
      * @return DateTime|null
      */

--- a/src/Models/LoteRPS.php
+++ b/src/Models/LoteRPS.php
@@ -20,6 +20,13 @@ class LoteRPS implements DocumentForIssuance
     public string $urlNotificacao;
 
     /**
+     * Identificador único para criar NFSE
+     * Este serve também para burlar a validação de duplicidade
+     * @var string
+     */
+    public string $ID = '';
+
+    /**
      * Permite especificar a Data e Hora para agendar a emissão da Nota Fiscal.
      * @var DateTime
      * @see https://webmaniabr.com/docs/rest-api-nfse/#informacoes-nota-fiscal
@@ -38,6 +45,16 @@ class LoteRPS implements DocumentForIssuance
     public function getUrlNotificacao() : string
     {
         return $this->urlNotificacao;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getID()
+    {
+        if (isset($this->ID)){
+            return $this->ID;
+        }
     }
 
     /**

--- a/src/Models/NFSe.php
+++ b/src/Models/NFSe.php
@@ -30,6 +30,13 @@ class NFSe extends DocumentoFiscal implements DocumentForIssuance
     public DateTime $agendamento;
 
     /**
+     * Identificador único para criar NFSE
+     * Este serve também para burlar a validação de duplicidade
+     * @var string
+     */
+    public string $ID = '';
+
+    /**
      * Identificador único da NFS-e. Para consulta e Cancelamento.
      * @var string
      */
@@ -50,6 +57,16 @@ class NFSe extends DocumentoFiscal implements DocumentForIssuance
     {
         if (isset($this->urlNotificacao)){
             return $this->urlNotificacao;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getID()
+    {
+        if (isset($this->ID)){
+            return $this->ID;
         }
     }
 


### PR DESCRIPTION
O campo ID, foi sugerido pela Webmania para resolver um problema, em caso de duas notas idênticas. 
Este campo existe na documentação, porém não é possível utilizá-lo no SDK.